### PR TITLE
Fix protocol bugs found in review, and bump to 0.11.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Gemfile.lock is deliberately not listed: the Dockerfile copies it so the image installs the same
+# versions the mounted working tree will ask for.
+.git/
+.rspec_status
+.ruby-lsp/
+coverage/
+pkg/
+tmp/

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0'
+          - '3.3'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,6 +41,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+AGENTS.md
+CLAUDE.md

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
 Metrics:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Style/Documentation:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# check=skip=FromPlatformFlagConstDisallowed
+# The test suite loads the x86_64 libsecp256k1 / libgoldilocks bundled in spec/lib, and
+# spec/spec_helper.rb points at them unconditionally, so this image has to be linux/amd64
+# even on an arm64 host. It mirrors the CI runner (ubuntu x86_64).
+FROM --platform=linux/amd64 ruby:3.3
+
+# libsodium: dlopen'd by rbnacl, which lib/noise.rb requires unconditionally.
+# cargo: the blake3 gem is a Rust extension and is built at install time.
+# git: noise.gemspec calls `git ls-files` while the gemspec is evaluated.
+RUN apt-get update -qq \
+ && apt-get install -y --no-install-recommends build-essential git libsodium23 cargo \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work
+
+# Install the gems from the dependency definitions alone so the layer stays cached when only
+# the source changes. Gems live in BUNDLE_PATH (/usr/local/bundle), outside /work, so mounting
+# the working tree over /work at run time does not hide them.
+#
+# Gemfile.lock is gitignored, hence the glob: it is copied when the host has one so the image
+# installs the exact versions the mounted lock will ask for at run time, and skipped otherwise.
+COPY Gemfile* noise.gemspec ./
+COPY lib/noise/version.rb lib/noise/version.rb
+RUN bundle install
+
+# Run with the working tree mounted:
+#   docker run --rm -v "$PWD":/work noise-dev
+#   docker run --rm -v "$PWD":/work noise-dev bundle exec rubocop
+CMD ["bundle", "exec", "rspec"]

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,6 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-# Specify your gem's dependencies in noise.gemspec
+# Specify your gem's dependencies in noise.gemspec. The optional ed448, secp256k1-ruby and blake3
+# backends are development dependencies there, so the test suite covers all of them.
 gemspec
-
-# Use secp256k1 as ecdh function
-# gem 'secp256k1-ruby'
-
-# Use blake3 as hash function
-# gem 'blake3'

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ After installing, define an environment variable as follows:
 
          $ export LIBGOLDILOCKS=/usr/local/lib/libgoldilocks.so
 
+and, add this line to your Gemfile:
+
+```
+gem 'ed448'
+```
+
 If you use Secp256k1, you must install [libsecp256k1](https://github.com/bitcoin-core/secp256k1).
 
     $ git clone https://github.com/bitcoin-core/secp256k1

--- a/lib/noise.rb
+++ b/lib/noise.rb
@@ -21,14 +21,29 @@ module Noise
   autoload :Functions, 'noise/functions'
   autoload :State, 'noise/state'
 
-  def self.logger
-    @logger ||= Logger.new($stdout)
-  end
-end
+  # Some DH and hash functions are backed by a gem, and often a system library, that is only needed
+  # when the function appears in a protocol name. Loading one is therefore allowed to fail; the
+  # failure is remembered and reported by optional_dependency! when the function is used.
+  @unavailable_dependencies = {}
 
-def require_force(name)
-  require name
-  yield if block_given?
-rescue LoadError => e
-  Noise.logger.warn(e.message)
+  class << self
+    def logger
+      @logger ||= Logger.new($stdout)
+    end
+
+    def require_optional(name)
+      require name
+      yield if block_given?
+    rescue LoadError => e
+      @unavailable_dependencies[name] = e.message
+      logger.warn("Optional dependency '#{name}' is unavailable: #{e.message}")
+    end
+
+    def optional_dependency!(name)
+      reason = @unavailable_dependencies[name]
+      return if reason.nil?
+
+      raise Noise::Exceptions::MissingDependencyError, "'#{name}' could not be loaded: #{reason}"
+    end
+  end
 end

--- a/lib/noise.rb
+++ b/lib/noise.rb
@@ -8,7 +8,6 @@ require 'rbnacl'
 require 'ruby_hmac'
 require 'securerandom'
 
-require 'noise/utils/hash'
 require 'noise/utils/string'
 
 module Noise

--- a/lib/noise/connection/base.rb
+++ b/lib/noise/connection/base.rb
@@ -29,11 +29,15 @@ module Noise
         @handshake_started = true
       end
 
+      # Restarts the handshake with a fallback pattern, carrying over the keys of the aborted one.
+      #
+      # The roles swap here: the party that wrote the aborted message now reads, and the one that
+      # failed to read it now writes. Both sides are already in that state, so @next_message is
+      # deliberately left as it is rather than reset through initialize_next_message.
       def fallback(fallback_name)
         @protocol = Protocol.create(fallback_name)
         @handshake_started = false
         @handshake_finished = false
-        # initialize_next_message
         @local_keypairs = { e: @handshake_state.e, s: @handshake_state.s }
         @remote_keys = { re: @handshake_state.re, rs: @handshake_state.rs }
         start_handshake

--- a/lib/noise/connection/base.rb
+++ b/lib/noise/connection/base.rb
@@ -103,7 +103,7 @@ module Noise
         raise Noise::Exceptions::NoisePSKError if @protocol.pattern.psk_count != @psks.count
       end
 
-      def valid_keypairs?
+      def missing_keypairs?
         keypairs = @local_keypairs.merge(@remote_keys)
         @protocol.pattern.required_keypairs(initiator?).any? { |keypair| !keypairs[keypair] }
       end
@@ -111,7 +111,7 @@ module Noise
       def validate
         validate_psk! if @protocol.psk?
 
-        raise Noise::Exceptions::NoiseValidationError if valid_keypairs?
+        raise Noise::Exceptions::NoiseValidationError if missing_keypairs?
 
         true
       end

--- a/lib/noise/connection/base.rb
+++ b/lib/noise/connection/base.rb
@@ -67,8 +67,7 @@ module Noise
 
         @next_message = :read
         buffer = +''
-        result = @handshake_state.write_message(payload, buffer)
-        @handshake_finished = true if result
+        @handshake_finished = @handshake_state.write_message(payload, buffer)
         buffer
       end
 
@@ -82,8 +81,7 @@ module Noise
 
         @next_message = :write
         buffer = +''
-        result = @handshake_state.read_message(data, buffer)
-        @handshake_finished = true if result
+        @handshake_finished = @handshake_state.read_message(data, buffer)
         buffer
       end
 

--- a/lib/noise/connection/base.rb
+++ b/lib/noise/connection/base.rb
@@ -3,6 +3,9 @@
 module Noise
   module Connection
     class Base
+      # The Noise spec caps a handshake or transport message at 65535 bytes.
+      MAX_MESSAGE_LENGTH = 65_535
+
       attr_reader :protocol, :handshake_started, :handshake_finished, :handshake_hash, :handshake_state,
                   :cipher_state_encrypt, :cipher_state_decrypt, :cipher_state_handshake, :s, :rs
       attr_accessor :psks, :prologue
@@ -54,6 +57,10 @@ module Noise
         raise Noise::Exceptions::NoiseHandshakeError if @next_message != :write
         raise Noise::Exceptions::NoiseHandshakeError if @handshake_finished
 
+        if @handshake_state.expected_message_length(payload.bytesize) > MAX_MESSAGE_LENGTH
+          raise Noise::Exceptions::NoiseHandshakeError, 'Message exceeds the maximum length.'
+        end
+
         @next_message = :read
         buffer = +''
         result = @handshake_state.write_message(payload, buffer)
@@ -66,6 +73,8 @@ module Noise
         raise Noise::Exceptions::NoiseHandshakeError unless @handshake_started
         raise Noise::Exceptions::NoiseHandshakeError if @next_message != :read
         raise Noise::Exceptions::NoiseHandshakeError if @handshake_finished
+        raise Noise::Exceptions::NoiseHandshakeError, 'Message exceeds the maximum length.' if
+          data.bytesize > MAX_MESSAGE_LENGTH
 
         @next_message = :write
         buffer = +''

--- a/lib/noise/exceptions.rb
+++ b/lib/noise/exceptions.rb
@@ -6,6 +6,7 @@ module Noise
     autoload :EncryptError, 'noise/exceptions/encrypt_error'
     autoload :InvalidPublicKeyError, 'noise/exceptions/invalid_public_key_error'
     autoload :MaxNonceError, 'noise/exceptions/max_nonce_error'
+    autoload :MissingDependencyError, 'noise/exceptions/missing_dependency_error'
     autoload :ProtocolNameError, 'noise/exceptions/protocol_name_error'
     autoload :NoiseHandshakeError, 'noise/exceptions/noise_handshake_error'
     autoload :NoiseValidationError, 'noise/exceptions/noise_validation_error'

--- a/lib/noise/exceptions/invalid_public_key_error.rb
+++ b/lib/noise/exceptions/invalid_public_key_error.rb
@@ -3,8 +3,10 @@
 module Noise
   module Exceptions
     class InvalidPublicKeyError < StandardError
+      attr_reader :public_key
+
       def initialize(public_key)
-        super
+        super("Invalid public key: #{public_key.unpack1('H*')}")
         @public_key = public_key
       end
     end

--- a/lib/noise/exceptions/missing_dependency_error.rb
+++ b/lib/noise/exceptions/missing_dependency_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Noise
+  module Exceptions
+    class MissingDependencyError < RuntimeError
+    end
+  end
+end

--- a/lib/noise/functions/cipher/aes_gcm.rb
+++ b/lib/noise/functions/cipher/aes_gcm.rb
@@ -11,7 +11,7 @@ module Noise
           cipher.key = k
           cipher.iv = nonce_to_bytes(n)
           cipher.auth_data = ad
-          cipher.update(plaintext) + cipher.final + cipher.auth_tag
+          update(cipher, plaintext) + cipher.final + cipher.auth_tag
         rescue OpenSSL::Cipher::CipherError => e
           raise Noise::Exceptions::EncryptError, "Encrypt failed. #{e.message}", e.backtrace
         end
@@ -22,7 +22,7 @@ module Noise
           cipher.iv = nonce_to_bytes(n)
           cipher.auth_data = ad
           cipher.auth_tag = ciphertext[-16..]
-          cipher.update(ciphertext[0...-16]) + cipher.final
+          update(cipher, ciphertext[0...-16]) + cipher.final
         rescue OpenSSL::Cipher::CipherError => e
           raise Noise::Exceptions::DecryptError, "Decrpyt failed. #{e.message}", e.backtrace
         end
@@ -40,6 +40,16 @@ module Noise
         # 32 bytes filled with zeros.
         def rekey(k)
           encrypt(k, MAX_NONCE, '', "\x00" * 32)[0...32]
+        end
+
+        private
+
+        # A zero-length payload is normal in a Noise message, but the openssl gem shipped with
+        # Ruby 3.0 raises ArgumentError('data must not be empty') instead of returning ''.
+        def update(cipher, data)
+          return String.new if data.empty?
+
+          cipher.update(data)
         end
       end
     end

--- a/lib/noise/functions/cipher/aes_gcm.rb
+++ b/lib/noise/functions/cipher/aes_gcm.rb
@@ -27,8 +27,9 @@ module Noise
           raise Noise::Exceptions::DecryptError, "Decrpyt failed. #{e.message}", e.backtrace
         end
 
+        # 4 zero bytes followed by n as a big-endian 64 bit integer.
         def nonce_to_bytes(n)
-          "\x00" * 4 + format('%16x', n).htb
+          "\x00" * 4 + [n].pack('Q>')
         end
 
         # Returns a new 32-byte cipher key as a pseudorandom function of k.

--- a/lib/noise/functions/cipher/cha_cha_poly.rb
+++ b/lib/noise/functions/cipher/cha_cha_poly.rb
@@ -31,7 +31,7 @@ module Noise
         # zerolen is a zero-length byte sequence, and zeros is a sequence of
         # 32 bytes filled with zeros.
         def rekey(k)
-          encrypt(k, MAX_NONCE, '', "\x00" * 32)[0..32]
+          encrypt(k, MAX_NONCE, '', "\x00" * 32)[0...32]
         end
       end
     end

--- a/lib/noise/functions/cipher/cha_cha_poly.rb
+++ b/lib/noise/functions/cipher/cha_cha_poly.rb
@@ -20,8 +20,9 @@ module Noise
           raise Noise::Exceptions::DecryptError, "Decrpyt failed. #{e.message}", e.backtrace
         end
 
+        # 4 zero bytes followed by n as a little-endian 64 bit integer.
         def nonce_to_bytes(n)
-          "\x00" * 4 + format('%16x', n).htb.reverse
+          "\x00" * 4 + [n].pack('Q<')
         end
 
         # Returns a new 32-byte cipher key as a pseudorandom function of k.

--- a/lib/noise/functions/dh/ed448.rb
+++ b/lib/noise/functions/dh/ed448.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
-require_force('ed448') { Ed448.init }
+Noise.require_optional('ed448') { Ed448.init }
 
 module Noise
   module Functions
     module DH
       class ED448
-        DHLEN = Ed448::X448::X448_PRIVATE_BYTES
+        # Ed448::X448::X448_PRIVATE_BYTES, spelled out so this file loads without the gem.
+        DHLEN = 56
+
+        def initialize
+          Noise.optional_dependency!('ed448')
+        end
 
         def generate_keypair
           private_key = SecureRandom.random_bytes(DHLEN)

--- a/lib/noise/functions/dh/secp256k1.rb
+++ b/lib/noise/functions/dh/secp256k1.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
-require_force 'secp256k1'
+Noise.require_optional 'secp256k1'
 
 module Noise
   module Functions
     module DH
       class Secp256k1
+        def initialize
+          Noise.optional_dependency!('secp256k1')
+        end
+
         def generate_keypair
           group = ECDSA::Group::Secp256k1
           private_key = 1 + SecureRandom.random_number(group.order - 1)

--- a/lib/noise/functions/dh/secp256k1.rb
+++ b/lib/noise/functions/dh/secp256k1.rb
@@ -23,7 +23,7 @@ module Noise
         def dh(private_key, public_key)
           key = ::Secp256k1::PublicKey.new(pubkey: public_key, raw: true)
           key.ecdh(private_key)
-        rescue ::Secp256k1::AssertError => _e
+        rescue ::Secp256k1::AssertError
           raise Noise::Exceptions::InvalidPublicKeyError, public_key
         end
 

--- a/lib/noise/functions/hash.rb
+++ b/lib/noise/functions/hash.rb
@@ -10,14 +10,17 @@ module Noise
       autoload :Blake3, 'noise/functions/hash/blake3'
 
       def self.hmac_hash(key, data, digest)
-        if digest.include?('SHA')
+        case digest
+        when /SHA/
           OpenSSL::HMAC.digest(OpenSSL::Digest.new(digest), key, data)
-        elsif digest.include?('BLAKE2b')
+        when /BLAKE2b/
           Noise::Functions::Hash::Blake2bHMAC.new(key).update(data).digest
-        elsif digest.include?('BLAKE2s')
+        when /BLAKE2s/
           Noise::Functions::Hash::Blake2sHMAC.new(key).update(data).digest
-        elsif digest.include?('BLAKE3')
+        when /BLAKE3/
           Noise::Functions::Hash::Blake3HMAC.new(key).update(data).digest
+        else
+          raise Noise::Exceptions::ProtocolNameError, "Unsupported hash function: #{digest}"
         end
       end
 

--- a/lib/noise/functions/hash/blake3.rb
+++ b/lib/noise/functions/hash/blake3.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_force 'blake3'
+Noise.require_optional 'blake3'
 
 module Noise
   module Functions
@@ -8,6 +8,11 @@ module Noise
       class Blake3
         HASHLEN = 32
         BLOCKLEN = 64
+
+        def initialize
+          Noise.optional_dependency!('blake3')
+        end
+
         def hash(data)
           ::Blake3.digest(data)
         end

--- a/lib/noise/functions/hash/blake3.rb
+++ b/lib/noise/functions/hash/blake3.rb
@@ -6,8 +6,8 @@ module Noise
   module Functions
     module Hash
       class Blake3
-        HASHLEN = 64
-        BLOCKLEN = 128
+        HASHLEN = 32
+        BLOCKLEN = 64
         def hash(data)
           ::Blake3.digest(data)
         end

--- a/lib/noise/pattern.rb
+++ b/lib/noise/pattern.rb
@@ -88,29 +88,39 @@ module Noise
     class Fallback
     end
 
+    PSK_REGEX = /\Apsk(\d+)\z/
+
     def self.parse(s)
-      if s.start_with?('psk')
-        index = s.gsub(/psk/, '').to_i
-        Modifier::Psk.new(index)
-      elsif s == 'fallback'
-        Modifier::Fallback.new
-      else
-        raise Noise::Exceptions::UnsupportedModifierError
-      end
+      matched = PSK_REGEX.match(s)
+      return Modifier::Psk.new(matched[1].to_i) if matched
+      return Modifier::Fallback.new if s == 'fallback'
+
+      raise Noise::Exceptions::UnsupportedModifierError, "Unsupported modifier: #{s}"
     end
   end
 
   class Pattern
     attr_reader :name, :tokens, :modifiers, :psk_count, :fallback
 
+    NAME_REGEX = /\A([A-Z1]+)([^A-Z]*)\z/
+
     def self.create(name)
-      pattern_set = name.scan(/([A-Z1]+)([^A-Z]*)/)&.first
-      pattern = pattern_set&.first
-      modifiers = pattern_set[1].split('+').map { |s| Modifier.parse(s) }
-      class_name = "Noise::Pattern#{pattern}"
-      klass = Object.const_get(class_name)
-      klass.new(modifiers)
+      matched = NAME_REGEX.match(name)
+      raise Noise::Exceptions::ProtocolNameError, "Malformed pattern name: #{name}" unless matched
+
+      modifiers = matched[2].split('+').map { |s| Modifier.parse(s) }
+      pattern_class(matched[1]).new(modifiers)
     end
+
+    def self.pattern_class(pattern)
+      klass = Object.const_get("Noise::Pattern#{pattern}")
+      raise NameError unless klass.is_a?(Class) && klass < Pattern
+
+      klass
+    rescue NameError
+      raise Noise::Exceptions::ProtocolNameError, "Unsupported pattern: #{pattern}"
+    end
+    private_class_method :pattern_class
 
     def initialize(modifiers)
       @pre_messages = [[], []]

--- a/lib/noise/pattern.rb
+++ b/lib/noise/pattern.rb
@@ -129,7 +129,8 @@ module Noise
         case modifier
         when Modifier::Psk
           index = modifier.index
-          raise Noise::Exceptions::PSKValueError if index / 2 > @tokens.size
+          # psk0 prepends to the first message, pskN appends to the Nth one.
+          raise Noise::Exceptions::PSKValueError if index > @tokens.size
 
           if index.zero?
             @tokens[0].insert(0, Token::PSK)

--- a/lib/noise/pattern.rb
+++ b/lib/noise/pattern.rb
@@ -101,7 +101,7 @@ module Noise
   end
 
   class Pattern
-    attr_reader :tokens, :modifiers, :psk_count, :fallback
+    attr_reader :name, :tokens, :modifiers, :psk_count, :fallback
 
     def self.create(name)
       pattern_set = name.scan(/([A-Z1]+)([^A-Z]*)/)&.first
@@ -150,24 +150,48 @@ module Noise
 
     def required_keypairs_of_initiator
       required = []
-      required << :s if %w[K X I].include?(@name[0])
-      required << :rs if one_way? || @name[1] == 'K'
+      required << :s if initiator_static?
+      required << :rs if responder_static_pre_shared?
       required
     end
 
     def required_keypairs_of_responder
       required = []
-      required << :rs if @name[0] == 'K'
-      required << :s if one_way? || %w[K X].include?(@name[1])
+      required << :rs if initiator_static_pre_shared?
+      required << :s if responder_static?
       required
     end
 
     def initiator_pre_messages
-      @pre_messages[0].dup
+      (@pre_messages[0] || []).dup
     end
 
     def responder_pre_messages
-      @pre_messages[1].dup
+      (@pre_messages[1] || []).dup
+    end
+
+    # A party needs a static keypair when its static public key is either pre-shared with the peer or
+    # transmitted during the handshake. Deriving this from the pattern itself keeps deferred patterns
+    # (whose names carry a '1', e.g. X1K) working, unlike inspecting single characters of the name.
+    def initiator_static?
+      initiator_static_pre_shared? || sends_static?(0)
+    end
+
+    def responder_static?
+      responder_static_pre_shared? || sends_static?(1)
+    end
+
+    def initiator_static_pre_shared?
+      initiator_pre_messages.include?(Token::S)
+    end
+
+    def responder_static_pre_shared?
+      responder_pre_messages.include?(Token::S)
+    end
+
+    # The initiator writes the messages at even indexes, the responder the ones at odd indexes.
+    def sends_static?(offset)
+      offset.step(@tokens.size - 1, 2).any? { |i| @tokens[i].include?(Token::S) }
     end
 
     def one_way?

--- a/lib/noise/protocol.rb
+++ b/lib/noise/protocol.rb
@@ -25,8 +25,11 @@ module Noise
     }.stringify_keys.freeze
 
     def self.create(name)
-      prefix, pattern_name, dh_name, cipher_name, hash_name = name.split('_')
-      raise Noise::Exceptions::ProtocolNameError if prefix != 'Noise'
+      parts = name.split('_')
+      raise Noise::Exceptions::ProtocolNameError, "Malformed protocol name: #{name}" unless parts.size == 5
+
+      prefix, pattern_name, dh_name, cipher_name, hash_name = parts
+      raise Noise::Exceptions::ProtocolNameError, "Malformed protocol name: #{name}" if prefix != 'Noise'
 
       new(name, pattern_name, cipher_name, hash_name, dh_name)
     end
@@ -44,7 +47,8 @@ module Noise
       @cipher_fn = CIPHER[cipher_name]&.new
       @hash_fn = HASH[hash_name]&.new
       @dh_fn = DH[dh_name]&.new
-      raise Noise::Exceptions::ProtocolNameError unless @cipher_fn && @hash_fn && @dh_fn
+      raise Noise::Exceptions::ProtocolNameError, "Unsupported function in: #{@name}" unless
+        @cipher_fn && @hash_fn && @dh_fn
     end
 
     def psk?

--- a/lib/noise/protocol.rb
+++ b/lib/noise/protocol.rb
@@ -6,23 +6,23 @@ module Noise
     attr_reader :name, :pattern
 
     CIPHER = {
-      'AESGCM': Noise::Functions::Cipher::AesGcm,
-      'ChaChaPoly': Noise::Functions::Cipher::ChaChaPoly
-    }.stringify_keys.freeze
+      'AESGCM' => Noise::Functions::Cipher::AesGcm,
+      'ChaChaPoly' => Noise::Functions::Cipher::ChaChaPoly
+    }.freeze
 
     DH = {
-      '25519': Noise::Functions::DH::ED25519,
-      '448': Noise::Functions::DH::ED448,
-      'secp256k1': Noise::Functions::DH::Secp256k1
-    }.stringify_keys.freeze
+      '25519' => Noise::Functions::DH::ED25519,
+      '448' => Noise::Functions::DH::ED448,
+      'secp256k1' => Noise::Functions::DH::Secp256k1
+    }.freeze
 
     HASH = {
-      'BLAKE2b': Noise::Functions::Hash::Blake2b,
-      'BLAKE2s': Noise::Functions::Hash::Blake2s,
-      'SHA256': Noise::Functions::Hash::Sha256,
-      'SHA512': Noise::Functions::Hash::Sha512,
-      'BLAKE3': Noise::Functions::Hash::Blake3
-    }.stringify_keys.freeze
+      'BLAKE2b' => Noise::Functions::Hash::Blake2b,
+      'BLAKE2s' => Noise::Functions::Hash::Blake2s,
+      'SHA256' => Noise::Functions::Hash::Sha256,
+      'SHA512' => Noise::Functions::Hash::Sha512,
+      'BLAKE3' => Noise::Functions::Hash::Blake3
+    }.freeze
 
     def self.create(name)
       parts = name.split('_')

--- a/lib/noise/state/cipher_state.rb
+++ b/lib/noise/state/cipher_state.rb
@@ -10,6 +10,7 @@ module Noise
     #
     class CipherState
       MAX_NONCE = 2**64 - 1
+      TAG_LENGTH = 16
 
       attr_reader :k, :n
 
@@ -46,6 +47,9 @@ module Noise
       def decrypt_with_ad(ad, ciphertext)
         return ciphertext unless key?
         raise Noise::Exceptions::MaxNonceError if @n == MAX_NONCE
+        # Without this the ciphers slice a nil authentication tag out of the truncated input.
+        raise Noise::Exceptions::DecryptError, 'Ciphertext is shorter than the tag.' if
+          ciphertext.bytesize < TAG_LENGTH
 
         plaintext = @cipher.decrypt(@k, @n, ad, ciphertext)
         @n += 1

--- a/lib/noise/state/cipher_state.rb
+++ b/lib/noise/state/cipher_state.rb
@@ -14,7 +14,7 @@ module Noise
 
       attr_reader :k, :n
 
-      def initialize(cipher: AesGcm.new)
+      def initialize(cipher:)
         @cipher = cipher
       end
 

--- a/lib/noise/state/handshake_state.rb
+++ b/lib/noise/state/handshake_state.rb
@@ -31,8 +31,9 @@ module Noise
 
         initiator_keypair_getter, responder_keypair_getter = get_keypair_getter(initiator)
 
-        # Sets message_patterns to the message patterns from handshake_pattern
-        @message_patterns = @protocol.pattern.tokens.dup
+        # Sets message_patterns to the message patterns from handshake_pattern. The inner arrays are
+        # copied too, so consuming them here can never reach back into the shared Pattern.
+        @message_patterns = @protocol.pattern.tokens.map(&:dup)
 
         process_initiator_pre_messages(initiator_keypair_getter)
         process_fallback(initiator_keypair_getter)

--- a/lib/noise/state/handshake_state.rb
+++ b/lib/noise/state/handshake_state.rb
@@ -127,8 +127,7 @@ module Noise
         pattern.each do |token|
           case token
           when Noise::Token::E
-            message, re = extract_key(message, false)
-            @re ||= re
+            message, @re = extract_key(message, false)
             mix_e(@re)
           when Noise::Token::S
             message, @rs = extract_key(message, true)

--- a/lib/noise/state/handshake_state.rb
+++ b/lib/noise/state/handshake_state.rb
@@ -100,6 +100,7 @@ module Noise
       end
 
       # Takes a payload byte sequence which may be zero-length, and a message_buffer to write the output into
+      # @return [Boolean] true if this was the last handshake message, false otherwise.
       def write_message(payload, message_buffer)
         pattern = @message_patterns.shift
 
@@ -118,11 +119,12 @@ module Noise
           end
         end
         message_buffer << @symmetric_state.encrypt_and_hash(payload)
-        @symmetric_state.split if @message_patterns.empty?
+        finish_handshake
       end
 
       # Takes a byte sequence containing a Noise handshake message,
       # and a payload_buffer to write the message's plaintext payload into
+      # @return [Boolean] true if this was the last handshake message, false otherwise.
       def read_message(message, payload_buffer)
         pattern = @message_patterns.shift
         pattern.each do |token|
@@ -139,10 +141,18 @@ module Noise
           end
         end
         payload_buffer << @symmetric_state.decrypt_and_hash(message)
-        @symmetric_state.split if @message_patterns.empty?
+        finish_handshake
       end
 
       private
+
+      # Splits into the transport cipher states once every message pattern has been processed.
+      def finish_handshake
+        return false unless @message_patterns.empty?
+
+        @symmetric_state.split
+        true
+      end
 
       def extract_key(message, is_encrypted)
         len = @protocol.dh_fn.dhlen

--- a/lib/noise/state/handshake_state.rb
+++ b/lib/noise/state/handshake_state.rb
@@ -152,6 +152,8 @@ module Noise
           else
             0
           end
+        raise Noise::Exceptions::NoiseHandshakeError, 'Message is too short.' if message.bytesize < len + offset
+
         key = message[0...len + offset]
         message = message[(len + offset)..]
         key = @symmetric_state.decrypt_and_hash(key) if is_encrypted

--- a/lib/noise/utils/hash.rb
+++ b/lib/noise/utils/hash.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class Hash
-  def stringify_keys
-    keys.each_with_object({}) do |key, h|
-      h[key.to_s] = self[key]
-    end
-  end
-end

--- a/lib/noise/utils/string.rb
+++ b/lib/noise/utils/string.rb
@@ -1,11 +1,25 @@
 # frozen_string_literal: true
 
-class String
-  def htb
-    [self].pack('H*')
-  end
+module Noise
+  module Utils
+    # Hex conversion helpers. Offered as a refinement so that requiring this gem does not add methods
+    # to String for the whole process.
+    #
+    #   using Noise::Utils::HexString
+    #   '0102'.htb     # => "\x01\x02"
+    #   "\x01\x02".bth # => "0102"
+    module HexString
+      refine ::String do
+        # hex to binary
+        def htb
+          [self].pack('H*')
+        end
 
-  def bth
-    unpack('H*').first
+        # binary to hex
+        def bth
+          unpack1('H*')
+        end
+      end
+    end
   end
 end

--- a/lib/noise/version.rb
+++ b/lib/noise/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Noise
-  VERSION = '0.10.1'
+  VERSION = '0.11.0'
 end

--- a/noise.gemspec
+++ b/noise.gemspec
@@ -22,19 +22,23 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'blake3'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'secp256k1-ruby'
 
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'simplecov-json'
 
+  # Optional backends. Each one is needed only when its function appears in a protocol name, and
+  # each also needs a system library that cannot be installed as a gem, so none of them is a runtime
+  # dependency. Add the one you need to your own Gemfile; see the README for the system libraries.
+  spec.add_development_dependency 'blake3'
+  spec.add_development_dependency 'ed448'
+  spec.add_development_dependency 'secp256k1-ruby'
+
   spec.add_runtime_dependency 'ecdsa'
-  spec.add_runtime_dependency 'ed448'
   spec.add_runtime_dependency 'rbnacl'
   spec.add_runtime_dependency 'ruby-hmac'
 end

--- a/spec/noise/connection_spec.rb
+++ b/spec/noise/connection_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe Noise::Connection do
     end
   end
 
+  describe '#start_handshake' do
+    let(:connection) { Noise::Connection::Initiator.new('Noise_NN_25519_AESGCM_SHA256') }
+
+    before { connection.start_handshake }
+
+    it 'copies the message patterns instead of sharing them with the protocol pattern' do
+      tokens = connection.protocol.pattern.tokens
+      expect(connection.handshake_state.message_patterns).to eq tokens
+      expect(connection.handshake_state.message_patterns.first).not_to equal tokens.first
+    end
+  end
+
   describe 'message length validation' do
     let(:name) { 'Noise_NN_25519_AESGCM_SHA256' }
     let(:initiator) { Noise::Connection::Initiator.new(name) }

--- a/spec/noise/connection_spec.rb
+++ b/spec/noise/connection_spec.rb
@@ -70,4 +70,49 @@ RSpec.describe Noise::Connection do
       end
     end
   end
+
+  describe 'message length validation' do
+    let(:name) { 'Noise_NN_25519_AESGCM_SHA256' }
+    let(:initiator) { Noise::Connection::Initiator.new(name) }
+    let(:responder) { Noise::Connection::Responder.new(name) }
+    let(:message) { initiator.write_message('') }
+
+    before do
+      initiator.start_handshake
+      responder.start_handshake
+    end
+
+    context 'when the handshake message is truncated' do
+      it 'raises NoiseHandshakeError instead of failing on a nil slice' do
+        expect { responder.read_message(message[0...10]) }
+          .to raise_error(Noise::Exceptions::NoiseHandshakeError, 'Message is too short.')
+      end
+    end
+
+    context 'when the handshake message is longer than the maximum length' do
+      it {
+        expect { responder.read_message('a' * (described_class::Base::MAX_MESSAGE_LENGTH + 1)) }
+          .to raise_error(Noise::Exceptions::NoiseHandshakeError, 'Message exceeds the maximum length.')
+      }
+    end
+
+    context 'when the payload would make the message longer than the maximum length' do
+      it {
+        expect { initiator.write_message('a' * described_class::Base::MAX_MESSAGE_LENGTH) }
+          .to raise_error(Noise::Exceptions::NoiseHandshakeError, 'Message exceeds the maximum length.')
+      }
+    end
+
+    context 'when the transport message is shorter than the authentication tag' do
+      before do
+        responder.read_message(message)
+        initiator.read_message(responder.write_message(''))
+      end
+
+      it {
+        expect { responder.decrypt('short') }
+          .to raise_error(Noise::Exceptions::DecryptError, 'Ciphertext is shorter than the tag.')
+      }
+    end
+  end
 end

--- a/spec/noise/connection_spec.rb
+++ b/spec/noise/connection_spec.rb
@@ -52,5 +52,22 @@ RSpec.describe Noise::Connection do
         it { expect { subject }.to raise_error(Noise::Exceptions::NoiseValidationError) }
       end
     end
+
+    context 'deferred pattern' do
+      let(:name) { 'Noise_X1K_25519_AESGCM_SHA256' }
+
+      context 'valid' do
+        let(:keypairs) { { s: ('00' * 32).htb, e: nil, rs: ('00' * 32).htb, re: nil } }
+
+        it { is_expected.to be true }
+      end
+
+      # X1K pre-shares the responder's static key, so the initiator must know rs.
+      context 'missing remote static key' do
+        let(:keypairs) { { s: ('00' * 32).htb, e: nil, rs: nil, re: nil } }
+
+        it { expect { subject }.to raise_error(Noise::Exceptions::NoiseValidationError) }
+      end
+    end
   end
 end

--- a/spec/noise/connection_spec.rb
+++ b/spec/noise/connection_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Connection do
   describe '#validate' do
     subject { connection.validate }

--- a/spec/noise/exceptions/invalid_public_key_error_spec.rb
+++ b/spec/noise/exceptions/invalid_public_key_error_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Noise::Exceptions::InvalidPublicKeyError do
+  subject { described_class.new(public_key) }
+
+  let(:public_key) { '028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7'.htb }
+
+  it { expect(subject.public_key).to eq public_key }
+
+  it {
+    expect(subject.message)
+      .to eq 'Invalid public key: 028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7'
+  }
+end

--- a/spec/noise/exceptions/invalid_public_key_error_spec.rb
+++ b/spec/noise/exceptions/invalid_public_key_error_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Exceptions::InvalidPublicKeyError do
   subject { described_class.new(public_key) }
 

--- a/spec/noise/functions/cipher/aes_gcm_spec.rb
+++ b/spec/noise/functions/cipher/aes_gcm_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Functions::Cipher::AesGcm do
   describe '#encrypt' do
     subject { cipher.encrypt(k, n, ad, plaintext).bth }

--- a/spec/noise/functions/cipher/aes_gcm_spec.rb
+++ b/spec/noise/functions/cipher/aes_gcm_spec.rb
@@ -47,4 +47,17 @@ RSpec.describe Noise::Functions::Cipher::AesGcm do
       expect(subject.bth).to eq 'fa6389ae59ea478a40fd68b33ec2273573090b6492d8d90f604d283ed6d2e338'
     }
   end
+
+  # A Noise message frequently carries a zero-length payload.
+  describe 'empty plaintext' do
+    subject { cipher.encrypt(k, n, ad, '') }
+
+    let(:cipher) { described_class.new }
+    let(:ad) { '955030590f203ad8e879746b277d16f8009661b332620edf641f7fe4c05a4f76'.htb }
+    let(:k) { '3f9e4cb3ec38f75adf64eed6acbea18d5aceaa3742b55f30282eb6c8ec945c53'.htb }
+    let(:n) { 1 }
+
+    it { expect(subject.bytesize).to eq 16 }
+    it { expect(cipher.decrypt(k, n, ad, subject)).to eq '' }
+  end
 end

--- a/spec/noise/functions/cipher/aes_gcm_spec.rb
+++ b/spec/noise/functions/cipher/aes_gcm_spec.rb
@@ -32,4 +32,17 @@ RSpec.describe Noise::Functions::Cipher::AesGcm do
 
     it { is_expected.to eq plaintext }
   end
+
+  describe '#rekey' do
+    subject { cipher.rekey(k) }
+
+    let(:cipher) { described_class.new }
+    let(:k) { '36b4b54fdef654f67adface4d65b1be19880031bdad72dff5909b9e63a4dcb68'.htb }
+
+    it { expect(subject.bytesize).to eq 32 }
+
+    it {
+      expect(subject.bth).to eq 'fa6389ae59ea478a40fd68b33ec2273573090b6492d8d90f604d283ed6d2e338'
+    }
+  end
 end

--- a/spec/noise/functions/cipher/cha_cha_poly_spec.rb
+++ b/spec/noise/functions/cipher/cha_cha_poly_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Functions::Cipher::ChaChaPoly do
   describe '#encrypt' do
     subject { cipher.encrypt(k, n, ad, plaintext).bth }

--- a/spec/noise/functions/cipher/cha_cha_poly_spec.rb
+++ b/spec/noise/functions/cipher/cha_cha_poly_spec.rb
@@ -53,4 +53,17 @@ RSpec.describe Noise::Functions::Cipher::ChaChaPoly do
       expect(subject.bth).to eq '3a1fd0e0f2af6b92dd0cf922fb60d0da2cb83cd92ea9c586100be673ef260af6'
     }
   end
+
+  # A Noise message frequently carries a zero-length payload.
+  describe 'empty plaintext' do
+    subject { cipher.encrypt(k, n, ad, '') }
+
+    let(:cipher) { described_class.new }
+    let(:ad) { '955030590f203ad8e879746b277d16f8009661b332620edf641f7fe4c05a4f76'.htb }
+    let(:k) { '36b4b54fdef654f67adface4d65b1be19880031bdad72dff5909b9e63a4dcb68'.htb }
+    let(:n) { 1 }
+
+    it { expect(subject.bytesize).to eq 16 }
+    it { expect(cipher.decrypt(k, n, ad, subject)).to eq '' }
+  end
 end

--- a/spec/noise/functions/cipher/cha_cha_poly_spec.rb
+++ b/spec/noise/functions/cipher/cha_cha_poly_spec.rb
@@ -38,4 +38,17 @@ RSpec.describe Noise::Functions::Cipher::ChaChaPoly do
 
     it { is_expected.to eq plaintext }
   end
+
+  describe '#rekey' do
+    subject { cipher.rekey(k) }
+
+    let(:cipher) { described_class.new }
+    let(:k) { '36b4b54fdef654f67adface4d65b1be19880031bdad72dff5909b9e63a4dcb68'.htb }
+
+    it { expect(subject.bytesize).to eq 32 }
+
+    it {
+      expect(subject.bth).to eq '3a1fd0e0f2af6b92dd0cf922fb60d0da2cb83cd92ea9c586100be673ef260af6'
+    }
+  end
 end

--- a/spec/noise/functions/dh/ed25519_spec.rb
+++ b/spec/noise/functions/dh/ed25519_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Functions::DH::ED25519 do
   # https://tools.ietf.org/html/rfc7748#section-6.1
   describe '#dh' do

--- a/spec/noise/functions/dh/ed448_spec.rb
+++ b/spec/noise/functions/dh/ed448_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Functions::DH::ED448 do
   # https://tools.ietf.org/html/rfc7748#section-6.2
   describe '#dh' do

--- a/spec/noise/functions/dh/secp256k1_spec.rb
+++ b/spec/noise/functions/dh/secp256k1_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Functions::DH::Secp256k1 do
   # https://github.com/lightningnetwork/lightning-rfc/blob/master/08-transport.md#initiator-tests
   describe '#dh' do

--- a/spec/noise/functions/hash/blake2s_spec.rb
+++ b/spec/noise/functions/hash/blake2s_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Functions::Hash::Blake2s do
   describe 'blake2s_hash' do
     subject { Noise::Functions::Hash::Blake2sDigester.new(key: key).update(data).digest.bth }

--- a/spec/noise/functions/hash_spec.rb
+++ b/spec/noise/functions/hash_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::Functions::Hash do
   describe '.hmac_hash' do
     subject { described_class.hmac_hash(key, data, digest).bth }
@@ -35,7 +37,10 @@ RSpec.describe Noise::Functions::Hash do
   end
 
   describe '.hkdf' do
-    subject { described_class.hkdf(chaining_key, input_key_material, num_outputs, digest).map(&:bth) }
+    # Symbol#to_proc does not see refinements, so bth needs an explicit block.
+    subject do
+      described_class.hkdf(chaining_key, input_key_material, num_outputs, digest).map { |output| output.bth } # rubocop:disable Style/SymbolProc
+    end
 
     context 'SHA256 - num_outputs=2' do
       let(:chaining_key) { '4e6f6973655f4e4e5f32353531395f41455347434d5f53484132353600000000'.htb }

--- a/spec/noise/functions/hash_spec.rb
+++ b/spec/noise/functions/hash_spec.rb
@@ -110,4 +110,11 @@ RSpec.describe Noise::Functions::Hash do
       it { is_expected.to eq expected }
     end
   end
+
+  describe '.hmac_hash with an unsupported digest' do
+    it {
+      expect { described_class.hmac_hash('key', 'data', 'MD5') }
+        .to raise_error(Noise::Exceptions::ProtocolNameError, 'Unsupported hash function: MD5')
+    }
+  end
 end

--- a/spec/noise/pattern_spec.rb
+++ b/spec/noise/pattern_spec.rb
@@ -245,6 +245,42 @@ RSpec.describe Noise::Protocol do
     end
   end
 
+  describe '#apply_pattern_modifiers' do
+    subject { Noise::Pattern.create(name).apply_pattern_modifiers }
+
+    # NN has two messages, so psk0 through psk2 are in range.
+    context 'psk0' do
+      let(:name) { 'NNpsk0' }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'psk2' do
+      let(:name) { 'NNpsk2' }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'psk3' do
+      let(:name) { 'NNpsk3' }
+
+      it { expect { subject }.to raise_error(Noise::Exceptions::PSKValueError) }
+    end
+
+    # XK has three messages, so psk3 is the last valid index.
+    context 'psk3 on a three message pattern' do
+      let(:name) { 'XKpsk3' }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
+    context 'psk4 on a three message pattern' do
+      let(:name) { 'XKpsk4' }
+
+      it { expect { subject }.to raise_error(Noise::Exceptions::PSKValueError) }
+    end
+  end
+
   # A deferred pattern only postpones DH operations, so it needs exactly the same keypairs as the
   # fundamental pattern it derives from.
   describe '#required_keypairs of deferred patterns' do

--- a/spec/noise/pattern_spec.rb
+++ b/spec/noise/pattern_spec.rb
@@ -215,5 +215,56 @@ RSpec.describe Noise::Protocol do
 
       it { is_expected.to eq [:s] }
     end
+
+    describe 'X1K(initiator)' do
+      let(:initiator) { true }
+      let(:name) { 'X1K' }
+
+      it { is_expected.to eq %i[s rs] }
+    end
+
+    describe 'X1K(responder)' do
+      let(:initiator) { false }
+      let(:name) { 'X1K' }
+
+      it { is_expected.to eq [:s] }
+    end
+
+    describe 'K1X(initiator)' do
+      let(:initiator) { true }
+      let(:name) { 'K1X' }
+
+      it { is_expected.to eq [:s] }
+    end
+
+    describe 'K1X(responder)' do
+      let(:initiator) { false }
+      let(:name) { 'K1X' }
+
+      it { is_expected.to eq %i[rs s] }
+    end
+  end
+
+  # A deferred pattern only postpones DH operations, so it needs exactly the same keypairs as the
+  # fundamental pattern it derives from.
+  describe '#required_keypairs of deferred patterns' do
+    {
+      'NK1' => 'NK', 'NX1' => 'NX',
+      'X1N' => 'XN', 'X1K' => 'XK', 'XK1' => 'XK', 'X1K1' => 'XK',
+      'X1X' => 'XX', 'XX1' => 'XX', 'X1X1' => 'XX',
+      'K1N' => 'KN', 'K1K' => 'KK', 'KK1' => 'KK', 'K1K1' => 'KK',
+      'K1X' => 'KX', 'KX1' => 'KX', 'K1X1' => 'KX',
+      'I1N' => 'IN', 'I1K' => 'IK', 'IK1' => 'IK', 'I1K1' => 'IK',
+      'I1X' => 'IX', 'IX1' => 'IX', 'I1X1' => 'IX'
+    }.each do |deferred, fundamental|
+      describe deferred do
+        it "requires the same keypairs as #{fundamental}" do
+          expect(Noise::Pattern.create(deferred).required_keypairs(true))
+            .to eq Noise::Pattern.create(fundamental).required_keypairs(true)
+          expect(Noise::Pattern.create(deferred).required_keypairs(false))
+            .to eq Noise::Pattern.create(fundamental).required_keypairs(false)
+        end
+      end
+    end
   end
 end

--- a/spec/noise/protocol_spec.rb
+++ b/spec/noise/protocol_spec.rb
@@ -27,5 +27,59 @@ RSpec.describe Noise::Protocol do
 
       it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
     end
+
+    context 'wrong prefix' do
+      let(:name) { 'NoiseX_NN_25519_AESGCM_SHA256' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
+    end
+
+    context 'too few components' do
+      let(:name) { 'Noise' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
+    end
+
+    context 'too many components' do
+      let(:name) { 'Noise_NN_25519_AESGCM_SHA256_EXTRA' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
+    end
+
+    context 'unknown pattern' do
+      let(:name) { 'Noise_ZZ_25519_AESGCM_SHA256' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
+    end
+
+    context 'empty pattern name' do
+      let(:name) { 'Noise__25519_AESGCM_SHA256' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
+    end
+
+    context 'unknown modifier' do
+      let(:name) { 'Noise_NNfoo_25519_AESGCM_SHA256' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::UnsupportedModifierError }
+    end
+
+    context 'unknown dh function' do
+      let(:name) { 'Noise_NN_9999_AESGCM_SHA256' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
+    end
+
+    context 'unknown cipher function' do
+      let(:name) { 'Noise_NN_25519_UNKNOWN_SHA256' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
+    end
+
+    context 'unknown hash function' do
+      let(:name) { 'Noise_NN_25519_AESGCM_UNKNOWN' }
+
+      it { expect { subject }.to raise_error Noise::Exceptions::ProtocolNameError }
+    end
   end
 end

--- a/spec/noise/state/symmetric_state_spec.rb
+++ b/spec/noise/state/symmetric_state_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 RSpec.describe Noise::State::SymmetricState do
   let(:state) do
     connection = Noise::Connection::Initiator.new('Noise_XKpsk3_25519_ChaChaPoly_SHA256')

--- a/spec/vectors_spec.rb
+++ b/spec/vectors_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+using Noise::Utils::HexString
+
 require 'json'
 
 RSpec.describe 'Vectors' do
@@ -57,8 +59,11 @@ RSpec.describe 'Vectors' do
           keypairs_resp = get_keypairs(v, false)
           responder = Noise::Connection::Responder.new(protocol_name, keypairs: keypairs_resp)
           if v.key?(:init_psks) && v.key?(:resp_psks)
-            initiator.psks = v[:init_psks].map(&:htb)
-            responder.psks = v[:resp_psks].map(&:htb)
+            # Symbol#to_proc does not see refinements, so htb needs an explicit block.
+            # rubocop:disable Style/SymbolProc
+            initiator.psks = v[:init_psks].map { |psk| psk.htb }
+            responder.psks = v[:resp_psks].map { |psk| psk.htb }
+            # rubocop:enable Style/SymbolProc
           end
 
           initiator.prologue = v[:init_prologue].htb


### PR DESCRIPTION
Fixes the problems found while reviewing the library, one per commit, and bumps to 0.11.0.

Based on `ruby_3.3`, so "Add support for ruby 3.3" is included here as well.

## Correctness

- **`ChaChaPoly#rekey` returned a 33 byte key.** `[0..32]` is an inclusive range; `AesGcm#rekey` already used `[0...32]`.
- **Keypair validation was wrong for every deferred pattern.** `required_keypairs_of_initiator` / `_of_responder` inspected single characters of the pattern name, so X1K, X1K1, I1K and I1K1 dropped the initiator's `:rs` and X1X, K1K and NX1 dropped `:s`. Validation passed with a missing key and the handshake blew up later with `TypeError: no implicit conversion of nil into String`. Now derived from the pre-messages and message patterns, and deferred patterns agree with the fundamental patterns they derive from.
- **Out-of-range psk indexes passed validation.** The bound was `index / 2 > @tokens.size`, so `Noise_NNpsk3_...` reached `@tokens[index - 1] << Token::PSK` on nil.
- **BLAKE3 declared HASHLEN 64 / BLOCKLEN 128**, borrowed from BLAKE2b. BLAKE3 is 32 over 64 blocks, so neither the `h` padding nor the HMAC block size could interoperate.
- **The ephemeral key read off the wire was discarded** when `re` was already set, while its bytes were still consumed and the stale key mixed in.

## Input validation

- Message lengths are checked before slicing. A truncated handshake message raised `TypeError` from `mix_hash`; a truncated transport message made the ciphers slice a nil authentication tag. `Connection::Base` also enforces the 65535 byte cap on handshake messages.
- Every malformed protocol name now raises `ProtocolNameError` with the offending name. `Protocol.create('Noise')` used to raise `NoMethodError` from `nil.scan`, and an unknown pattern raised `NameError: uninitialized constant Noise::PatternZZ`. The pattern class lookup is guarded by a `Pattern` subclass check so a name cannot reach an unrelated constant through `const_get`.
- `hmac_hash` raises instead of returning nil for an unrecognised digest.

## Diagnostics

`require_force` logged a LoadError and carried on, so a missing native library surfaced much later as something unrelated. `Noise.require_optional` now records why the load failed and `Noise.optional_dependency!` raises `MissingDependencyError` carrying that reason, so ED448, Secp256k1 and Blake3 refuse to be built when their backing gem is unusable. `InvalidPublicKeyError` formats the key as hex instead of passing raw bytes as the message.

## Cleanups

Nonces are built with `pack` rather than a space-padded `format('%16x', n)` that only worked because `pack('H*')` maps a space to a zero nibble. Handshake completion is returned explicitly instead of being read off the truthiness of the last statement. Message patterns are copied deeply into the handshake state. `valid_keypairs?` returned true when a keypair was *missing*, so it is now `missing_keypairs?`. `CipherState`'s unusable `cipher:` default is gone, and the commented-out `initialize_next_message` in `fallback` is replaced by an explanation of why the direction is deliberately kept.

## Tooling

- **Dockerfile.** The libsecp256k1 and libgoldilocks builds under `spec/lib` are x86_64, so on an arm64 host 605 of 1986 examples fail with dlopen architecture errors that have nothing to do with the code. The image pins linux/amd64 to mirror the CI runner and adds libsodium, cargo and git.
- **Dependencies.** `ed448` was a runtime dependency while `blake3` and `secp256k1-ruby` were development dependencies, even though all three back an optional function and need a system library. All three are development dependencies now, and the README documents `ed448` alongside the others.
- **CI.** Lint moves from 3.0 to 3.3, and 3.4 joins the test matrix. `.rubocop.yml` used `Metrics/LineLength`, which rubocop rejected as the wrong namespace on every run, so the 120 column limit was never actually applied.

## Breaking changes

- `String#htb`, `String#bth` and `Hash#stringify_keys` are no longer defined on the core classes. The hex helpers moved to the `Noise::Utils::HexString` refinement; call sites need `using Noise::Utils::HexString`.
- `Connection::Base#valid_keypairs?` is now `#missing_keypairs?`.
- `ed448` is no longer a runtime dependency.

## Verification

`docker run --rm -v "$PWD":/work noise-dev` reports **1986 examples, 0 failures** and rubocop reports no offenses. The same suite was run against `ruby:3.4` before adding it to the matrix, also 0 failures.

Not verified: the BLAKE3 length fix. BLAKE3 is an extension to the Noise spec with no published test vectors, so nothing exercises the corrected constants.
