### PR TITLE
Raise NoisePSKError when psks were never set

### DIFF
--- a/lib/noise/connection/base.rb
+++ b/lib/noise/connection/base.rb
@@ -98,9 +98,15 @@ module Noise
       end
 
       def validate_psk!
+        raise Noise::Exceptions::NoisePSKError, 'psks are not set.' if @psks.nil?
         # Invalid psk length! Has to be 32 bytes long
-        raise Noise::Exceptions::NoisePSKError if @psks.any? { |psk| psk.bytesize != 32 }
-        raise Noise::Exceptions::NoisePSKError if @protocol.pattern.psk_count != @psks.count
+        raise Noise::Exceptions::NoisePSKError, 'psks have to be 32 bytes long.' if
+          @psks.any? { |psk| psk.bytesize != 32 }
+
+        return if @protocol.pattern.psk_count == @psks.count
+
+        raise Noise::Exceptions::NoisePSKError,
+              "This protocol needs #{@protocol.pattern.psk_count} psks, got #{@psks.count}."
       end
 
       def missing_keypairs?

--- a/spec/noise/connection_spec.rb
+++ b/spec/noise/connection_spec.rb
@@ -23,12 +23,23 @@ RSpec.describe Noise::Connection do
         it { is_expected.to be true }
       end
 
+      # The connection is usable without psks for any other pattern, so nothing sets @psks unless
+      # the caller does.
+      context 'psks never set' do
+        let(:name) { 'Noise_KNpsk0_25519_AESGCM_SHA256' }
+
+        it { expect { subject }.to raise_error(Noise::Exceptions::NoisePSKError, 'psks are not set.') }
+      end
+
       context 'too long psk' do
         let(:name) { 'Noise_KNpsk0_25519_AESGCM_SHA256' }
 
         before { connection.psks = [('00' * 33).htb] }
 
-        it { expect { subject }.to raise_error(Noise::Exceptions::NoisePSKError) }
+        it {
+          expect { subject }
+            .to raise_error(Noise::Exceptions::NoisePSKError, 'psks have to be 32 bytes long.')
+        }
       end
 
       context 'unmatch psk type' do
@@ -36,7 +47,10 @@ RSpec.describe Noise::Connection do
 
         before { connection.psks = [('00' * 32).htb] }
 
-        it { expect { subject }.to raise_error(Noise::Exceptions::NoisePSKError) }
+        it {
+          expect { subject }
+            .to raise_error(Noise::Exceptions::NoisePSKError, 'This protocol needs 2 psks, got 1.')
+        }
       end
     end
 


### PR DESCRIPTION
## Problem

A psk pattern requires the caller to set the keys through `Connection#psks=`. Nothing else assigns the ivar, so a connection whose psks were never set reaches `validate_psk!` with `@psks` still nil:

```ruby
conn = Noise::Connection::Initiator.new('Noise_KNpsk0_25519_AESGCM_SHA256', keypairs: keypairs)
conn.start_handshake
# => NoMethodError: undefined method `any?' for nil
#    lib/noise/connection/base.rb:102:in `validate_psk!'
```

Forgetting `psks=` is the single most likely way to misuse a psk pattern, and it is exactly the case that reports a Ruby internal error instead of `NoisePSKError`.

## Fix

Guard the nil case in `validate_psk!` so the caller gets the exception the API already defines for this.

While there: all three psk failures raised a bare `NoisePSKError` with no message, so a caller could not tell which rule they broke. Each one now says what happened.

```ruby
def validate_psk!
  raise Noise::Exceptions::NoisePSKError, 'psks are not set.' if @psks.nil?
  # Invalid psk length! Has to be 32 bytes long
  raise Noise::Exceptions::NoisePSKError, 'psks have to be 32 bytes long.' if
    @psks.any? { |psk| psk.bytesize != 32 }

  return if @protocol.pattern.psk_count == @psks.count

  raise Noise::Exceptions::NoisePSKError,
        "This protocol needs #{@protocol.pattern.psk_count} psks, got #{@psks.count}."
end
```

The reported call now raises `Noise::Exceptions::NoisePSKError: psks are not set.`

## Tests

A `psks never set` example covers the nil case. The two existing psk examples asserted only the exception class, so they passed just as happily when the wrong rule fired; both now assert the message as well.

## Verification

- `1991 examples, 608 failures` on the host, with **zero failures outside the 448 and secp256k1 groups** — the same baseline as before the change. Those 608 are the known environment problem: the libgoldilocks and libsecp256k1 builds committed under `spec/lib` are x86_64 while the host Ruby is arm64.
- `rubocop`: 60 files, no offenses.

Not done: the full suite has **not** been run in the linux/amd64 container that normally clears those 608. The Docker daemon on this machine is failing with `input/output error` writing its containerd metadata, so neither a build nor a run was possible. CI covers that gap, but worth a second look before merging if the CI run is not conclusive.
