### PR TITLE
feat: expose transport nonce and rekey on Connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,31 @@ cipher = initiator.encrypt("Hello, World!") # => "\xDA\xC7\xD7as\v\xFA\xCC,\xB3\
 plain = responder.decrypt(cipher) # => "Hello, World!"
 ```
 
+#### Out-of-order transport messages
+
+Each party counts the transport messages of each direction with a nonce. If the transport layer can
+deliver messages out of order or lose them, it has to carry the nonce of each message, and the
+receiver sets the nonce before decrypting. Restore the previous value if the message fails to
+authenticate, so that the following messages are still decryptable.
+
+```
+initiator.encryption_nonce # => 0
+responder.decryption_nonce = 2 # decrypt the message numbered 2 next
+plain = responder.decrypt(cipher)
+```
+
+#### Rekey
+
+Rekeying replaces the key of one direction with `REKEY(k)`, so that a key compromised later cannot
+decrypt the messages that came before it. The nonce keeps counting. Both parties must rekey the
+matching direction at the same point of the message stream; when that happens is up to the
+application protocol.
+
+```
+initiator.rekey_encryption
+responder.rekey_decryption
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/noise/connection/base.rb
+++ b/lib/noise/connection/base.rb
@@ -86,15 +86,56 @@ module Noise
       end
 
       def encrypt(data)
-        raise Noise::Exceptions::NoiseHandshakeError unless @handshake_finished
-
-        @cipher_state_encrypt.encrypt_with_ad('', data)
+        transport_cipher_state(:encrypt).encrypt_with_ad('', data)
       end
 
       def decrypt(data)
-        raise Noise::Exceptions::NoiseHandshakeError unless @handshake_finished
+        transport_cipher_state(:decrypt).decrypt_with_ad('', data)
+      end
 
-        @cipher_state_decrypt.decrypt_with_ad('', data)
+      # @return [Integer] the nonce the next #encrypt call uses.
+      def encryption_nonce
+        transport_cipher_state(:encrypt).n
+      end
+
+      # @return [Integer] the nonce the next #decrypt call uses.
+      def decryption_nonce
+        transport_cipher_state(:decrypt).n
+      end
+
+      # Sets the nonce of the next #encrypt call. Needed when the transport layer numbers the
+      # messages itself instead of relying on the sender and the receiver counting in step.
+      #
+      # @param [Integer] nonce a value between 0 and CipherState::MAX_NONCE.
+      def encryption_nonce=(nonce)
+        transport_cipher_state(:encrypt).nonce = nonce
+      end
+
+      # Sets the nonce of the next #decrypt call. This is how the Noise spec handles transport
+      # messages that arrive out of order: the receiver sets n to the nonce of the message it is
+      # about to decrypt, and restores the previous value if the message fails to authenticate.
+      #
+      # @param [Integer] nonce a value between 0 and CipherState::MAX_NONCE.
+      def decryption_nonce=(nonce)
+        transport_cipher_state(:decrypt).nonce = nonce
+      end
+
+      # Replaces the key used by #encrypt with REKEY(k), so that the old key cannot decrypt the
+      # messages that follow. Both parties must rekey the matching direction at the same point of
+      # the message stream, which is up to the application protocol to agree on.
+      #
+      # @return [void]
+      def rekey_encryption
+        transport_cipher_state(:encrypt).rekey
+        nil
+      end
+
+      # Replaces the key used by #decrypt with REKEY(k). See #rekey_encryption.
+      #
+      # @return [void]
+      def rekey_decryption
+        transport_cipher_state(:decrypt).rekey
+        nil
       end
 
       def validate_psk!
@@ -123,6 +164,23 @@ module Noise
         @handshake_state = nil
         @symmetric_state = nil
         @cipher_state_handshake = nil
+      end
+
+      private
+
+      # Returns the transport CipherState of the given direction.
+      #
+      # One-way patterns leave the direction the caller cannot use as nil, so the absence of a
+      # cipher state is reported the same way as a handshake that has not finished yet.
+      #
+      # @param [Symbol] direction :encrypt or :decrypt.
+      def transport_cipher_state(direction)
+        raise Noise::Exceptions::NoiseHandshakeError unless @handshake_finished
+
+        cipher_state = direction == :encrypt ? @cipher_state_encrypt : @cipher_state_decrypt
+        raise Noise::Exceptions::NoiseHandshakeError, "This party cannot #{direction} messages." unless cipher_state
+
+        cipher_state
       end
     end
   end

--- a/lib/noise/exceptions.rb
+++ b/lib/noise/exceptions.rb
@@ -4,6 +4,7 @@ module Noise
   module Exceptions
     autoload :DecryptError, 'noise/exceptions/decrypt_error'
     autoload :EncryptError, 'noise/exceptions/encrypt_error'
+    autoload :InvalidNonceError, 'noise/exceptions/invalid_nonce_error'
     autoload :InvalidPublicKeyError, 'noise/exceptions/invalid_public_key_error'
     autoload :MaxNonceError, 'noise/exceptions/max_nonce_error'
     autoload :MissingDependencyError, 'noise/exceptions/missing_dependency_error'

--- a/lib/noise/exceptions/invalid_nonce_error.rb
+++ b/lib/noise/exceptions/invalid_nonce_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Noise
+  module Exceptions
+    # Raised when a nonce given to CipherState#nonce= is not an unsigned 64-bit integer.
+    class InvalidNonceError < RuntimeError
+    end
+  end
+end

--- a/lib/noise/state/cipher_state.rb
+++ b/lib/noise/state/cipher_state.rb
@@ -29,7 +29,17 @@ module Noise
         !@k.nil?
       end
 
+      # Sets n, the nonce the next encrypt_with_ad or decrypt_with_ad call uses. This is SetNonce()
+      # of the Noise spec, needed to decrypt transport messages that arrive out of order.
+      #
+      # The value is checked here because the ciphers pack n into 8 bytes: a value outside the
+      # unsigned 64-bit range silently produces a wrong nonce instead of an error.
+      #
+      # @param [Integer] nonce a value between 0 and MAX_NONCE.
+      # @raise [Noise::Exceptions::InvalidNonceError] if nonce is out of that range.
       def nonce=(nonce)
+        raise Noise::Exceptions::InvalidNonceError unless nonce.is_a?(Integer) && nonce.between?(0, MAX_NONCE)
+
         @n = nonce
       end
 
@@ -56,6 +66,9 @@ module Noise
         plaintext
       end
 
+      # Replaces k with REKEY(k). n is left as it is, as the Noise spec requires.
+      #
+      # @return [String] the new 32 bytes key.
       def rekey
         @k = @cipher.rekey(@k)
       end

--- a/spec/noise/connection_spec.rb
+++ b/spec/noise/connection_spec.rb
@@ -129,4 +129,105 @@ RSpec.describe Noise::Connection do
       }
     end
   end
+
+  describe 'transport nonce' do
+    let(:name) { 'Noise_NN_25519_AESGCM_SHA256' }
+    let(:initiator) { Noise::Connection::Initiator.new(name) }
+    let(:responder) { Noise::Connection::Responder.new(name) }
+
+    before do
+      initiator.start_handshake
+      responder.start_handshake
+      responder.read_message(initiator.write_message(''))
+      initiator.read_message(responder.write_message(''))
+    end
+
+    it 'starts at zero and counts the transport messages' do
+      expect(initiator.encryption_nonce).to eq 0
+      initiator.encrypt('first')
+      expect(initiator.encryption_nonce).to eq 1
+      expect(responder.decryption_nonce).to eq 0
+    end
+
+    it 'lets the receiver decrypt messages that arrive out of order' do
+      first = initiator.encrypt('first')
+      second = initiator.encrypt('second')
+
+      responder.decryption_nonce = 1
+      expect(responder.decrypt(second)).to eq 'second'
+      responder.decryption_nonce = 0
+      expect(responder.decrypt(first)).to eq 'first'
+    end
+
+    it 'rejects a nonce outside the unsigned 64-bit range' do
+      expect { responder.decryption_nonce = 2**64 }.to raise_error(Noise::Exceptions::InvalidNonceError)
+      expect { initiator.encryption_nonce = -1 }.to raise_error(Noise::Exceptions::InvalidNonceError)
+      expect(responder.decryption_nonce).to eq 0
+    end
+
+    context 'before the handshake finishes' do
+      let(:fresh) { Noise::Connection::Initiator.new(name) }
+
+      it { expect { fresh.encryption_nonce = 1 }.to raise_error(Noise::Exceptions::NoiseHandshakeError) }
+      it { expect { fresh.decryption_nonce }.to raise_error(Noise::Exceptions::NoiseHandshakeError) }
+    end
+  end
+
+  describe 'transport rekey' do
+    let(:name) { 'Noise_NN_25519_AESGCM_SHA256' }
+    let(:initiator) { Noise::Connection::Initiator.new(name) }
+    let(:responder) { Noise::Connection::Responder.new(name) }
+
+    before do
+      initiator.start_handshake
+      responder.start_handshake
+      responder.read_message(initiator.write_message(''))
+      initiator.read_message(responder.write_message(''))
+    end
+
+    it 'keeps both parties in sync when the matching directions rekey' do
+      initiator.rekey_encryption
+      responder.rekey_decryption
+
+      expect(responder.decrypt(initiator.encrypt('after rekey'))).to eq 'after rekey'
+    end
+
+    it 'does not reset the nonce' do
+      initiator.encrypt('first')
+      initiator.rekey_encryption
+
+      expect(initiator.encryption_nonce).to eq 1
+    end
+
+    it 'makes the message undecryptable for a receiver that did not rekey' do
+      initiator.rekey_encryption
+
+      expect { responder.decrypt(initiator.encrypt('after rekey')) }
+        .to raise_error(Noise::Exceptions::DecryptError)
+    end
+  end
+
+  describe 'one-way pattern' do
+    let(:name) { 'Noise_N_25519_AESGCM_SHA256' }
+    let(:static) { Noise::Protocol.create(name).dh_fn.class.from_private(('11' * 32).htb) }
+    let(:initiator) { Noise::Connection::Initiator.new(name, keypairs: { rs: static.public_key }) }
+    let(:responder) { Noise::Connection::Responder.new(name, keypairs: { s: static.private_key }) }
+
+    before do
+      initiator.start_handshake
+      responder.start_handshake
+      responder.read_message(initiator.write_message(''))
+    end
+
+    it 'has no cipher state for the direction the party cannot use' do
+      expect { initiator.rekey_decryption }
+        .to raise_error(Noise::Exceptions::NoiseHandshakeError, 'This party cannot decrypt messages.')
+      expect { initiator.decrypt('') }
+        .to raise_error(Noise::Exceptions::NoiseHandshakeError, 'This party cannot decrypt messages.')
+      expect { responder.rekey_encryption }
+        .to raise_error(Noise::Exceptions::NoiseHandshakeError, 'This party cannot encrypt messages.')
+      expect { responder.encryption_nonce }
+        .to raise_error(Noise::Exceptions::NoiseHandshakeError, 'This party cannot encrypt messages.')
+    end
+  end
 end

--- a/spec/noise/state/cipher_state_spec.rb
+++ b/spec/noise/state/cipher_state_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+using Noise::Utils::HexString
+
+RSpec.describe Noise::State::CipherState do
+  let(:state) do
+    described_class.new(cipher: Noise::Functions::Cipher::ChaChaPoly.new).tap { |s| s.initialize_key(key) }
+  end
+  let(:key) { ('01' * 32).htb }
+
+  describe '#nonce=' do
+    context 'with a value in the unsigned 64-bit range' do
+      it 'makes the next encryption use that nonce' do
+        state.nonce = 5
+        ciphertext = state.encrypt_with_ad('', 'message')
+
+        other = described_class.new(cipher: Noise::Functions::Cipher::ChaChaPoly.new)
+        other.initialize_key(key)
+        other.nonce = 5
+        expect(other.decrypt_with_ad('', ciphertext)).to eq 'message'
+        expect(state.n).to eq 6
+      end
+    end
+
+    context 'with the maximum nonce' do
+      it 'is accepted, and the encryption that follows is the one that fails' do
+        state.nonce = described_class::MAX_NONCE
+        expect(state.n).to eq described_class::MAX_NONCE
+        expect { state.encrypt_with_ad('', 'message') }.to raise_error(Noise::Exceptions::MaxNonceError)
+      end
+    end
+
+    context 'with a value above the unsigned 64-bit range' do
+      it 'is rejected instead of producing a truncated nonce' do
+        expect { state.nonce = 2**64 }.to raise_error(Noise::Exceptions::InvalidNonceError)
+        expect(state.n).to eq 0
+      end
+    end
+
+    context 'with a negative value' do
+      it { expect { state.nonce = -1 }.to raise_error(Noise::Exceptions::InvalidNonceError) }
+    end
+
+    context 'with a value that is not an integer' do
+      it { expect { state.nonce = 1.0 }.to raise_error(Noise::Exceptions::InvalidNonceError) }
+    end
+  end
+
+  describe '#rekey' do
+    it 'replaces the key and keeps the nonce' do
+      state.nonce = 3
+      expect { state.rekey }.to change(state, :k)
+      expect(state.n).to eq 3
+    end
+  end
+end


### PR DESCRIPTION
Adds the public API for the two transport-phase operations of the Noise spec that were reachable
only by touching a `Connection`'s internals, or not at all.

## SetNonce (spec section 11.4)

`CipherState#nonce=` existed, but the only way to reach it was
`conn.cipher_state_decrypt.nonce = n`, and it accepted anything.

- `Connection::Base#encryption_nonce` / `#decryption_nonce` read the nonce of each direction, and
  the matching writers set it. Out-of-order transport messages are handled by setting the nonce of
  the message about to be decrypted, and restoring the previous value if it fails to authenticate.
- `CipherState#nonce=` now rejects anything that is not an integer in `0..MAX_NONCE` with a new
  `Noise::Exceptions::InvalidNonceError`. `nonce = 2**64` used to be accepted and then silently
  truncated by `[n].pack('Q<')` in the next encryption, producing a nonce of 0. `MAX_NONCE` itself
  is still accepted, so the reserved value keeps failing where the spec says it should — in the
  encryption that follows, with `MaxNonceError`.

## Rekey (spec section 11.3)

`CipherState#rekey` was not exposed either.

- `Connection::Base#rekey_encryption` / `#rekey_decryption` replace the key of one direction with
  `REKEY(k)` and leave the nonce alone, as the spec requires. Both parties have to rekey the
  matching direction at the same point of the message stream; when that happens is up to the
  application protocol, so nothing here tries to negotiate it.

## Cipher state lookup

`#encrypt` and `#decrypt` checked `@handshake_finished` and then called through to a cipher state
that one-way patterns leave nil, so the responder of `Noise_N_...` calling `#encrypt` got
`NoMethodError` on nil. Both directions now go through one private `transport_cipher_state`, which
raises `NoiseHandshakeError` with `"This party cannot encrypt messages."` (or `decrypt`) instead.
The new nonce and rekey methods use the same lookup, so they report the same way.

## Documentation

README gains an "Out-of-order transport messages" and a "Rekey" section under Transport.

## Verification

`bundle exec rubocop` reports no offenses. `bundle exec rspec` on the CI runner's architecture is
expected to be green; the run on the author's arm64 machine reports 2005 examples with 608 failures,
all of them the documented ED448 / Secp256k1 dlopen failures caused by the x86_64 binaries under
`spec/lib`, and none in the code this PR touches.