### PR TITLE
fix: report an invalid public key the same way in every DH function

### DIFF
--- a/lib/noise/functions/dh/ed25519.rb
+++ b/lib/noise/functions/dh/ed25519.rb
@@ -12,8 +12,20 @@ module Noise
           Noise::Key.new(ECDSA::Format::IntegerOctetString.encode(private_key, 32), public_key.to_bytes)
         end
 
+        # Computes the X25519 shared secret for the given remote public key.
+        #
+        # RbNaCl reports a public key it cannot use in two different ways: a wrong length
+        # raises RbNaCl::LengthError, and an all-zero or low-order point raises
+        # RbNaCl::CryptoError. Both are translated to InvalidPublicKeyError so that a
+        # caller handling a peer-supplied key rescues the same class for every DH function.
+        # The length is checked before the call so that RbNaCl::LengthError raised for a
+        # malformed private key keeps propagating as itself.
         def dh(private_key, public_key)
+          raise Noise::Exceptions::InvalidPublicKeyError, public_key unless public_key.bytesize == DHLEN
+
           RbNaCl::GroupElement.new(public_key).mult(private_key).to_bytes
+        rescue RbNaCl::CryptoError
+          raise Noise::Exceptions::InvalidPublicKeyError, public_key
         end
 
         def dhlen

--- a/lib/noise/functions/dh/ed448.rb
+++ b/lib/noise/functions/dh/ed448.rb
@@ -19,8 +19,19 @@ module Noise
           Noise::Key.new(private_key, public_key)
         end
 
+        # Computes the X448 shared secret for the given remote public key.
+        #
+        # Ed448::X448.dh raises a plain RuntimeError when libgoldilocks rejects the base
+        # point because it lies in a small subgroup, and it silently zero-pads a public key
+        # shorter than DHLEN. The length is checked up front and the RuntimeError is
+        # translated, so an unusable remote key always surfaces as InvalidPublicKeyError,
+        # the same class the other DH functions raise.
         def dh(private_key, public_key)
+          raise Noise::Exceptions::InvalidPublicKeyError, public_key unless public_key.bytesize == DHLEN
+
           Ed448::X448.dh(public_key, private_key)
+        rescue RuntimeError
+          raise Noise::Exceptions::InvalidPublicKeyError, public_key
         end
 
         def dhlen

--- a/lib/noise/functions/dh/secp256k1.rb
+++ b/lib/noise/functions/dh/secp256k1.rb
@@ -6,6 +6,10 @@ module Noise
   module Functions
     module DH
       class Secp256k1
+        # Length of a compressed secp256k1 point. libsecp256k1 also accepts the 65-byte
+        # uncompressed form, but Noise exchanges only the compressed one.
+        DHLEN = 33
+
         def initialize
           Noise.optional_dependency!('secp256k1')
         end
@@ -20,7 +24,16 @@ module Noise
           )
         end
 
+        # Computes the ECDH shared secret for the given remote public key.
+        #
+        # A point that is not on the curve makes libsecp256k1 raise Secp256k1::AssertError,
+        # while a public key of any other length raises ArgumentError before the point is
+        # even parsed. Both are translated to InvalidPublicKeyError, matching the other DH
+        # functions. The length is checked here rather than left to the gem so that
+        # ArgumentError raised for a malformed private key keeps propagating as itself.
         def dh(private_key, public_key)
+          raise Noise::Exceptions::InvalidPublicKeyError, public_key unless public_key.bytesize == DHLEN
+
           key = ::Secp256k1::PublicKey.new(pubkey: public_key, raw: true)
           key.ecdh(private_key)
         rescue ::Secp256k1::AssertError
@@ -28,7 +41,7 @@ module Noise
         end
 
         def dhlen
-          33
+          DHLEN
         end
 
         def self.from_private(private_key)

--- a/spec/noise/functions/dh/ed25519_spec.rb
+++ b/spec/noise/functions/dh/ed25519_spec.rb
@@ -23,6 +23,64 @@ RSpec.describe Noise::Functions::DH::ED25519 do
     it { is_expected.to eq shared_key }
   end
 
+  describe '#dh with an invalid public key' do
+    let(:private_key) do
+      '77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a'.htb
+    end
+    let(:ed25519) { described_class.new }
+
+    context 'with an all-zero public key' do
+      let(:public_key) { ('00' * 32).htb }
+
+      it {
+        expect { ed25519.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+
+    context 'with a low order public key' do
+      # Point of order 8 listed in https://cr.yp.to/ecdh.html#validate
+      let(:public_key) do
+        'e0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800'.htb
+      end
+
+      it {
+        expect { ed25519.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+
+    context 'with a public key shorter than dhlen' do
+      let(:public_key) { ('01' * 31).htb }
+
+      it {
+        expect { ed25519.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+
+    context 'with a public key longer than dhlen' do
+      let(:public_key) { ('01' * 33).htb }
+
+      it {
+        expect { ed25519.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+  end
+
+  # The public key length is validated by #dh itself, so an error about the private key
+  # still comes straight from RbNaCl instead of being reported as a public key problem.
+  describe '#dh with an invalid private key' do
+    let(:private_key) { ('01' * 31).htb }
+    let(:public_key) do
+      'de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f'.htb
+    end
+    let(:ed25519) { described_class.new }
+
+    it { expect { ed25519.dh(private_key, public_key) }.to raise_error RbNaCl::LengthError }
+  end
+
   describe '#generate_keypair' do
     let(:dh) { described_class.new }
     let(:alice) { dh.generate_keypair }

--- a/spec/noise/functions/dh/ed448_spec.rb
+++ b/spec/noise/functions/dh/ed448_spec.rb
@@ -26,6 +26,41 @@ RSpec.describe Noise::Functions::DH::ED448 do
     it { is_expected.to eq shared_key }
   end
 
+  describe '#dh with an invalid public key' do
+    let(:private_key) do
+      '9a8f4925d1519f5775cf46b04b5800d4ee9ee8bae8bc5565d498c28d' \
+      'd9c9baf574a9419744897391006382a6f127ab1d9ac2d8c0a598726b'.htb
+    end
+    let(:ed448) { described_class.new }
+
+    context 'with an all-zero public key' do
+      let(:public_key) { ('00' * 56).htb }
+
+      it {
+        expect { ed448.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+
+    context 'with a public key shorter than dhlen' do
+      let(:public_key) { ('01' * 55).htb }
+
+      it {
+        expect { ed448.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+
+    context 'with a public key longer than dhlen' do
+      let(:public_key) { ('01' * 57).htb }
+
+      it {
+        expect { ed448.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+  end
+
   describe '#generate_keypair' do
     let(:dh) { described_class.new }
     let(:alice) { dh.generate_keypair }

--- a/spec/noise/functions/dh/secp256k1_spec.rb
+++ b/spec/noise/functions/dh/secp256k1_spec.rb
@@ -23,6 +23,47 @@ RSpec.describe Noise::Functions::DH::Secp256k1 do
     it { is_expected.to eq shared_key }
   end
 
+  describe '#dh with an invalid public key' do
+    let(:private_key) do
+      '1212121212121212121212121212121212121212121212121212121212121212'.htb
+    end
+    let(:secp256k1) { described_class.new }
+
+    context 'with a point that is not on the curve' do
+      let(:public_key) { "02#{'00' * 32}".htb }
+
+      it {
+        expect { secp256k1.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+
+    context 'with a public key shorter than dhlen' do
+      let(:public_key) { ('01' * 32).htb }
+
+      it {
+        expect { secp256k1.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+
+    context 'with an uncompressed public key' do
+      # libsecp256k1 accepts the 65-byte form, but Noise exchanges only the compressed one.
+      let(:public_key) do
+        point = ECDSA::Format::PointOctetString.decode(
+          '028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7'.htb,
+          ECDSA::Group::Secp256k1
+        )
+        ECDSA::Format::PointOctetString.encode(point, compression: false)
+      end
+
+      it {
+        expect { secp256k1.dh(private_key, public_key) }
+          .to raise_error Noise::Exceptions::InvalidPublicKeyError
+      }
+    end
+  end
+
   describe '#dh and generate_keypair' do
     let(:secp256k1) { described_class.new }
     let(:alice) { secp256k1.generate_keypair }


### PR DESCRIPTION
## Summary

A public key that comes from the peer is untrusted input, but each DH function reported a bad one differently, so a caller had no single exception class to rescue:

| | Before | After |
|---|---|---|
| `ED25519` | `RbNaCl::CryptoError` (all-zero / low-order point) and `RbNaCl::LengthError` (wrong length) leaked out of `#dh` | `Noise::Exceptions::InvalidPublicKeyError` |
| `ED448` | `RuntimeError: goldilocks_x448 failed.` leaked out, and a key shorter than 56 bytes was silently zero-padded by the FFI wrapper instead of being rejected | `Noise::Exceptions::InvalidPublicKeyError` |
| `Secp256k1` | a point off the curve already raised `InvalidPublicKeyError`, but any other length raised `ArgumentError` from the gem | `Noise::Exceptions::InvalidPublicKeyError` |

## Changes

- Translate the `RbNaCl` and libgoldilocks errors into `Noise::Exceptions::InvalidPublicKeyError`.
- Reject a public key whose length is not `dhlen` in all three functions.
- Check that length **before** calling the backend. Both `RbNaCl::GroupElement#mult` and `Secp256k1::PublicKey#ecdh` validate the private key too, so rescuing their errors wholesale would report a malformed *private* key as an invalid *public* key.
- Add `Secp256k1::DHLEN = 33`, replacing the literal in `#dhlen`. The 65-byte uncompressed form libsecp256k1 accepts is now rejected, since Noise exchanges only the compressed one.

## Test plan

- New specs in `spec/noise/functions/dh/{ed25519,ed448,secp256k1}_spec.rb` cover all-zero, low-order, off-curve, too-short, too-long and uncompressed public keys.
- One spec pins the opposite direction: an invalid private key still raises `RbNaCl::LengthError`, not `InvalidPublicKeyError`.
- `bundle exec rubocop` — no offenses.
- `docker run --rm -v "$PWD":/work noise-dev bundle exec rspec` — 2001 examples, 0 failures (the official test vectors are unaffected).
