### PR TITLE
fix: enforce the 65535 byte message limit on transport messages

### DIFF
--- a/lib/noise/connection/base.rb
+++ b/lib/noise/connection/base.rb
@@ -3,8 +3,11 @@
 module Noise
   module Connection
     class Base
-      # The Noise spec caps a handshake or transport message at 65535 bytes.
+      # The Noise spec caps a handshake or transport message at 65535 bytes. A transport message is
+      # the ciphertext, so the plaintext a caller may hand to encrypt is shorter by the
+      # authentication tag that ENCRYPT() appends.
       MAX_MESSAGE_LENGTH = 65_535
+      MAX_PLAINTEXT_LENGTH = MAX_MESSAGE_LENGTH - Noise::State::CipherState::TAG_LENGTH
 
       attr_reader :protocol, :handshake_started, :handshake_finished, :handshake_hash, :handshake_state,
                   :cipher_state_encrypt, :cipher_state_decrypt, :cipher_state_handshake, :s, :rs
@@ -86,11 +89,25 @@ module Noise
       end
 
       def encrypt(data)
-        transport_cipher_state(:encrypt).encrypt_with_ad('', data)
+        cipher_state = transport_cipher_state(:encrypt)
+        if data.bytesize > MAX_PLAINTEXT_LENGTH
+          raise Noise::Exceptions::MessageTooLongError,
+                "Plaintext is #{data.bytesize} bytes, which exceeds the maximum of #{MAX_PLAINTEXT_LENGTH}."
+        end
+
+        cipher_state.encrypt_with_ad('', data)
       end
 
       def decrypt(data)
-        transport_cipher_state(:decrypt).decrypt_with_ad('', data)
+        cipher_state = transport_cipher_state(:decrypt)
+        # Rejected before the cipher state is used, so an over-long message leaves n untouched
+        # and the connection usable, exactly as a failed decryption does.
+        if data.bytesize > MAX_MESSAGE_LENGTH
+          raise Noise::Exceptions::MessageTooLongError,
+                "Message is #{data.bytesize} bytes, which exceeds the maximum of #{MAX_MESSAGE_LENGTH}."
+        end
+
+        cipher_state.decrypt_with_ad('', data)
       end
 
       # @return [Integer] the nonce the next #encrypt call uses.

--- a/lib/noise/exceptions.rb
+++ b/lib/noise/exceptions.rb
@@ -7,6 +7,7 @@ module Noise
     autoload :InvalidNonceError, 'noise/exceptions/invalid_nonce_error'
     autoload :InvalidPublicKeyError, 'noise/exceptions/invalid_public_key_error'
     autoload :MaxNonceError, 'noise/exceptions/max_nonce_error'
+    autoload :MessageTooLongError, 'noise/exceptions/message_too_long_error'
     autoload :MissingDependencyError, 'noise/exceptions/missing_dependency_error'
     autoload :ProtocolNameError, 'noise/exceptions/protocol_name_error'
     autoload :NoiseHandshakeError, 'noise/exceptions/noise_handshake_error'

--- a/lib/noise/exceptions/message_too_long_error.rb
+++ b/lib/noise/exceptions/message_too_long_error.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Noise
+  module Exceptions
+    # Raised when a transport message would exceed, or does exceed, the 65535 byte limit the Noise
+    # specification places on every message. Kept apart from DecryptError so that a caller can tell a
+    # badly framed message from a failed authentication, which has very different security meaning.
+    class MessageTooLongError < StandardError
+    end
+  end
+end

--- a/spec/noise/connection_spec.rb
+++ b/spec/noise/connection_spec.rb
@@ -142,6 +142,39 @@ RSpec.describe Noise::Connection do
           .to raise_error(Noise::Exceptions::DecryptError, 'Ciphertext is shorter than the tag.')
       }
     end
+
+    context 'when the handshake has finished' do
+      let(:max_plaintext) { described_class::Base::MAX_PLAINTEXT_LENGTH }
+
+      before do
+        responder.read_message(message)
+        initiator.read_message(responder.write_message(''))
+      end
+
+      it 'encrypts the longest plaintext that still fits in a maximum length message' do
+        ciphertext = initiator.encrypt('a' * max_plaintext)
+
+        expect(ciphertext.bytesize).to eq described_class::Base::MAX_MESSAGE_LENGTH
+        expect(responder.decrypt(ciphertext)).to eq 'a' * max_plaintext
+      end
+
+      it 'rejects a plaintext whose ciphertext would exceed the maximum length' do
+        expect { initiator.encrypt('a' * (max_plaintext + 1)) }
+          .to raise_error(Noise::Exceptions::MessageTooLongError, /65520 bytes.*maximum of 65519/)
+
+        # The rejection happens before the cipher state is touched, so the connection stays usable.
+        expect(initiator.cipher_state_encrypt.n).to eq 0
+        expect(responder.decrypt(initiator.encrypt('hello'))).to eq 'hello'
+      end
+
+      it 'rejects a transport message longer than the maximum length' do
+        expect { responder.decrypt('a' * (described_class::Base::MAX_MESSAGE_LENGTH + 1)) }
+          .to raise_error(Noise::Exceptions::MessageTooLongError, /65536 bytes.*maximum of 65535/)
+
+        expect(responder.cipher_state_decrypt.n).to eq 0
+        expect(responder.decrypt(initiator.encrypt('hello'))).to eq 'hello'
+      end
+    end
   end
 
   describe 'transport nonce' do


### PR DESCRIPTION
## Summary

The Noise spec caps every message — handshake or transport — at 65535 bytes.
`Connection::Base#write_message` / `#read_message` already enforced that for the handshake phase
(`MAX_MESSAGE_LENGTH`), but `#encrypt` and `#decrypt` passed any length straight through to the
cipher state.

Two consequences:

| | Before | After |
|---|---|---|
| `encrypt` with a plaintext ≥ 65520 bytes | produced a ciphertext over the spec limit, which the peer cannot frame or accept | `Noise::Exceptions::MessageTooLongError` |
| `decrypt` with a message over 65535 bytes | reached the cipher state; on AEAD failure `n` had already advanced, desynchronising the nonce and killing the session | `MessageTooLongError`, raised before the cipher state is touched |

## Changes

- `MAX_PLAINTEXT_LENGTH = MAX_MESSAGE_LENGTH - CipherState::TAG_LENGTH` (65519). A transport
  message *is* the ciphertext, so the plaintext a caller may hand to `encrypt` is shorter by the
  authentication tag `ENCRYPT()` appends.
- `#encrypt` rejects a plaintext above `MAX_PLAINTEXT_LENGTH`; `#decrypt` rejects a message above
  `MAX_MESSAGE_LENGTH`.
- Both checks run **before** the cipher state is dereferenced, so an over-long message leaves `n`
  untouched and the connection usable — the same recovery behaviour a failed decryption has.
- New `Noise::Exceptions::MessageTooLongError`, kept apart from `DecryptError` so a caller can tell
  a badly framed message from a failed authentication. The two have very different security
  meaning: the first is a framing bug, the second is a possible attack.

## Tests

`spec/noise/connection_spec.rb` gains a transport-phase group covering:

- the boundary — a 65519 byte plaintext encrypts to exactly 65535 bytes and round-trips,
- `encrypt` at 65520 bytes raising `MessageTooLongError`, with `cipher_state_encrypt.n` still 0 and
  a subsequent `encrypt`/`decrypt` pair still working,
- `decrypt` at 65536 bytes raising `MessageTooLongError`, with `cipher_state_decrypt.n` still 0 and
  the connection still usable.

## Verification

- `bundle exec rubocop` — 60 files, no offenses.
- `docker run --rm -v "$PWD":/work noise-dev` — **1993 examples, 0 failures** (official test
  vectors unaffected; no vector uses a message anywhere near the limit).
- On the author's arm64 host, `bundle exec rspec` reports 608 failures, all ED448 / Secp256k1 specs
  hitting the known x86_64 `spec/lib` binaries. None outside those groups.

## Compatibility

A caller that previously encrypted a plaintext of 65520 bytes or more now gets an exception instead
of an over-long ciphertext. That ciphertext was not usable by a spec-conforming peer, so this
surfaces an existing bug rather than removing a working path. Applications sending large payloads
need to fragment them — the Noise spec leaves fragmentation to the application protocol.