### PR TITLE
fix: reject unusable private keys in Secp256k1.from_private

### DIFF
--- a/lib/noise/functions/dh/secp256k1.rb
+++ b/lib/noise/functions/dh/secp256k1.rb
@@ -51,7 +51,7 @@ module Noise
         def dh(private_key, public_key)
           raise Noise::Exceptions::InvalidPublicKeyError, public_key unless public_key.bytesize == DHLEN
 
-          scalar = private_key_scalar(private_key)
+          scalar = OpenSSL::BN.new(self.class.decode_private_key(private_key))
           shared = parse_public_key(public_key).mul(scalar)
           # A backstop rather than a reachable case: secp256k1 has cofactor 1, so a point that
           # parsed has order n, and the scalar is already known to be in [1, n-1]. It stays because
@@ -67,10 +67,31 @@ module Noise
         end
 
         def self.from_private(private_key)
-          group = ECDSA::Group::Secp256k1
-          scalar = ECDSA::Format::IntegerOctetString.decode(private_key)
-          point = group.generator.multiply_by_scalar(scalar)
+          scalar = decode_private_key(private_key)
+          point = ECDSA::Group::Secp256k1.generator.multiply_by_scalar(scalar)
           Noise::Key.new(private_key, ECDSA::Format::PointOctetString.encode(point, compression: true))
+        end
+
+        # Decodes a private key into the scalar it denotes, rejecting the values that cannot serve
+        # as one. Both entry points that take a private key go through this, so a key from_private
+        # accepts is one dh can use.
+        #
+        # Rejected are a length other than PRIVATE_KEY_LEN, zero, and anything at or above the
+        # group order: those scalars multiply every point to infinity, whose compressed encoding is
+        # the single byte 0x00. Without the check from_private would hand back a Noise::Key holding
+        # that one byte as its public key, and the handshake it is used in would fail only once the
+        # key reached the wire. A private key belongs to the caller rather than to the peer, so a
+        # bad one raises ArgumentError and not InvalidPublicKeyError.
+        def self.decode_private_key(private_key)
+          unless private_key.bytesize == PRIVATE_KEY_LEN
+            raise ArgumentError, "private key must be #{PRIVATE_KEY_LEN} bytes"
+          end
+
+          scalar = ECDSA::Format::IntegerOctetString.decode(private_key)
+          order = ECDSA::Group::Secp256k1.order
+          raise ArgumentError, 'private key is out of range' unless scalar.between?(1, order - 1)
+
+          scalar
         end
 
         private
@@ -87,22 +108,6 @@ module Noise
           OpenSSL::PKey::EC::Point.new(@group, public_key)
         rescue OpenSSL::PKey::EC::Point::Error
           raise Noise::Exceptions::InvalidPublicKeyError, public_key
-        end
-
-        # Decodes a private key into a scalar the curve accepts.
-        #
-        # A scalar of zero, or one that is a multiple of the group order, multiplies every point to
-        # infinity. Rejecting it here keeps that case from being reported as the peer's invalid
-        # public key.
-        def private_key_scalar(private_key)
-          unless private_key.bytesize == PRIVATE_KEY_LEN
-            raise ArgumentError, "private key must be #{PRIVATE_KEY_LEN} bytes"
-          end
-
-          scalar = OpenSSL::BN.new(private_key, 2)
-          raise ArgumentError, 'private key is out of range' if scalar <= 0 || scalar >= @group.order
-
-          scalar
         end
       end
     end

--- a/spec/noise/functions/dh/secp256k1_spec.rb
+++ b/spec/noise/functions/dh/secp256k1_spec.rb
@@ -5,6 +5,21 @@ require 'spec_helper'
 using Noise::Utils::HexString
 
 RSpec.describe Noise::Functions::DH::Secp256k1 do
+  describe '#initialize' do
+    # secp256k1 is builtin everywhere this suite runs, so the one OpenSSL that does not offer it -
+    # one restricted to a FIPS provider - is simulated by making the group refuse to build.
+    context 'when OpenSSL does not offer the curve' do
+      before do
+        allow(OpenSSL::PKey::EC::Group).to receive(:new)
+          .and_raise(OpenSSL::PKey::EC::Group::Error, 'unknown curve name')
+      end
+
+      it {
+        expect { described_class.new }.to raise_error Noise::Exceptions::MissingDependencyError
+      }
+    end
+  end
+
   # https://github.com/lightningnetwork/lightning-rfc/blob/master/08-transport.md#initiator-tests
   describe '#dh' do
     subject { secp256k1.dh(private_key, public_key).bth }
@@ -38,8 +53,10 @@ RSpec.describe Noise::Functions::DH::Secp256k1 do
       }
     end
 
-    # OpenSSL reads this as the point at infinity and raises nothing, so without the explicit
-    # check the shared secret would be a constant that whoever sent the key can precompute.
+    # 0x00 introduces the encoding of the point at infinity, which is one byte long, so 33 zero
+    # bytes are a malformed encoding and OpenSSL refuses to parse them. Pinned here because the
+    # secret that would follow from accepting the key - SHA256 of a constant - is one its sender
+    # could precompute.
     context 'with an all-zero public key' do
       let(:public_key) { ('00' * 33).htb }
 
@@ -118,6 +135,34 @@ RSpec.describe Noise::Functions::DH::Secp256k1 do
 
     it { expect(described_class.from_private(private_key).public_key.bth).to eq public_key }
     it { expect(described_class.from_private(private_key).private_key).to eq private_key }
+  end
+
+  # from_private is where a caller loads a static or ephemeral key of its own, so it rejects every
+  # private key dh rejects. Accepting one would return a Noise::Key whose public key is the single
+  # byte 0x00, the compressed encoding of infinity, and the handshake using it would fail only
+  # after that byte had been put on the wire.
+  describe '.from_private with an invalid private key' do
+    subject { described_class.from_private(private_key) }
+
+    context 'with a private key shorter than a scalar' do
+      let(:private_key) { ('01' * 31).htb }
+
+      it { expect { subject }.to raise_error ArgumentError }
+    end
+
+    context 'with an all-zero private key' do
+      let(:private_key) { ('00' * 32).htb }
+
+      it { expect { subject }.to raise_error ArgumentError }
+    end
+
+    context 'with a private key that is not below the group order' do
+      let(:private_key) do
+        'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141'.htb
+      end
+
+      it { expect { subject }.to raise_error ArgumentError }
+    end
   end
 
   describe '#dh and generate_keypair' do


### PR DESCRIPTION
## Summary

Follow-up to #24. That PR moved `Secp256k1#dh` onto OpenSSL and added a private key check —
32 bytes, scalar in `[1, n-1]` — but stated that "`generate_keypair` and `.from_private` are
untouched". `.from_private` is the other entry point that takes a private key: it is what
`Noise::Connection::Base` calls for a caller-supplied `keypairs[:s]` / `keypairs[:e]`. It went
through the `ecdsa` gem with no validation at all, so it accepted exactly the keys `#dh` rejects.

| `from_private(...)` | Before | After |
|---|---|---|
| 32 zero bytes | returns a `Noise::Key` whose `public_key` is `"\x00"` — 1 byte | `ArgumentError` |
| scalar equal to the group order | same 1-byte public key | `ArgumentError` |
| 31 bytes | returns a 33-byte public key; `#dh` later raises `ArgumentError` | `ArgumentError` |

`"\x00"` is the compressed encoding of the point at infinity. A caller that loaded such a key got
a keypair that failed only once its 1-byte public key had been written to the wire, or when `#dh`
raised mid-handshake — instead of failing where the key was supplied.

## Changes

- The private key check moves into `Secp256k1.decode_private_key`, and both `#dh` and
  `.from_private` go through it. A key `.from_private` accepts is now one `#dh` can use.
- `#dh` keeps its behaviour: the scalar is the same value, and `ArgumentError` rather than
  `InvalidPublicKeyError` still marks a key the caller owns as not the peer's fault. The instance
  helper `private_key_scalar` is removed as redundant.
- Corrected the comment on the all-zero public key example in the spec. It claimed OpenSSL "reads
  this as the point at infinity and raises nothing", which is true only of the `OpenSSL::BN`
  overload #24 deliberately avoids. With the `String` the implementation actually passes,
  `EC_POINT_oct2point` refuses the encoding while parsing, so the example is caught one layer
  earlier than the comment said and the `infinity?` backstop is not what makes it pass. The comment
  in `secp256k1.rb` had it right; the two now agree.

Nothing on the wire changes. The BOLT #8 shared secret and the `secp256k1` test vectors are
unaffected — only inputs that previously produced an unusable keypair now raise.

## Tests

- `.from_private` with a 31-byte key, an all-zero key, and a key equal to the group order, each
  raising `ArgumentError` — the three cases that previously succeeded.
- `#initialize` raising `MissingDependencyError` when OpenSSL does not offer the curve. #24 added
  that translation for a FIPS-restricted OpenSSL but left it as the only uncovered line in the
  file; the curve is builtin everywhere the suite runs, so the refusal is stubbed.

## Verification

- `bundle exec rubocop` — 63 files, no offenses.
- `bundle exec rspec` on arm64 macOS — 2034 examples, 0 failures (2030 before; +4 examples).
- `spec/noise/functions/dh/secp256k1_spec.rb` — 15 examples, 0 failures.
- `lib/noise/functions/dh/secp256k1.rb` now has no uncovered lines.
- The BOLT #8 initiator shared secret (`1e2fb3c8…fdcc3`) was recomputed after the change and is
  unchanged, as is `Noise_XK_secp256k1_ChaChaPoly_SHA256` in `spec/vectors/lightning.txt`.
- Each "Before" cell in the table above was observed on `master`, not inferred: `from_private`
  with a zero scalar returns a 1-byte public key rather than raising.